### PR TITLE
Support `https` registry URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 var JSONStream = require('JSONStream');
-var http = require('http');
+var http = require('http-https');
 var qs = require('querystring');
 var Transform = require('stream').Transform;
+
 
 /**
  * Expose `dependants`.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "tap test/*.js"
   },
   "dependencies": {
-    "JSONStream": "~0.7.1"
+    "JSONStream": "~0.7.1",
+    "http-https": "^1.0.0"
   },
   "devDependencies": {
     "tap": "~0.4.6"


### PR DESCRIPTION
This allows using `module-usage` with a registry served over `https`
